### PR TITLE
Check the output of Py_GetArgcArgv before using it

### DIFF
--- a/_prctlmodule.c
+++ b/_prctlmodule.c
@@ -366,6 +366,9 @@ static int _Py_GetArgcArgv(int* argc, char ***argv) {
     char **buf = NULL , *arg0 = NULL, *ptr = 0, *limit = NULL;
 
     Py_GetArgcArgv(argc, &argv_w);
+    if (*argc < 1 || argv_w == NULL) {
+        return 0;
+    }
 
     buf = (char **)malloc((*argc + 1) * sizeof(char *));
     buf[*argc] = NULL;


### PR DESCRIPTION
With embedded python interpreter, `Py_GetArgcArgv` may not return any arguments. Therefore, the returned `argc` and `argw_v` pointer need to be verified before trying to use them, in order to avoid a segmentation fault (see pyinstaller/pyinstaller#5238).