### PR TITLE
tests: skip speculation enable if force-disabled

### DIFF
--- a/test_prctl.py
+++ b/test_prctl.py
@@ -328,6 +328,10 @@ class PrctlTest(unittest.TestCase):
        self.assertTrue(prctl.get_speculation_ctrl(prctl.SPEC_INDIRECT_BRANCH) > 0)
        self.assertRaises(ValueError, prctl.get_speculation_ctrl, 99)
        self.assertRaises(ValueError, prctl.set_speculation_ctrl, 99)
+
+       if prctl.get_speculation_ctrl(prctl.SPEC_STORE_BYPASS) & prctl.SPEC_FORCE_DISABLE:
+            self.skipTest("SPEC_STORE_BYPASS is force-disabled on this environment")
+
        prctl.set_speculation_ctrl(prctl.SPEC_STORE_BYPASS, prctl.SPEC_ENABLE)
        self.assertEqual(prctl.get_speculation_ctrl(prctl.SPEC_STORE_BYPASS) & ~prctl.SPEC_PRCTL, prctl.SPEC_ENABLE)
        prctl.set_speculation_ctrl(prctl.SPEC_STORE_BYPASS, prctl.SPEC_FORCE_DISABLE)


### PR DESCRIPTION
Avoids test failure on environments where PR_SPEC_FORCE_DISABLE is already set by skipping the enable step.

Fixes: https://github.com/seveas/python-prctl/issues/31